### PR TITLE
Fixed a bug in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ from pybinaryedge import BinaryEdge
 be = BinaryEdge(API_KEY)
 # Iterate over the first page of IPs having specific ssh configuration
 search = 'ssh.algorithms.encryption.keyword:"aes256-cbc" ssh.banner.keyword:"SSH-2.0-OpenSSH_LeadSec"'
-for ip in be.host_search(search):
-    print('%s': % ip['origin']['ip'])
+results = be.host_search(search)
+for ip in results['events']:
+    print("%s" %(ip['target']['ip']))
 ```
 
 List of functions implemented :


### PR DESCRIPTION
Example didn't work in Python2 or Python3, was getting an error about string indices needing to be integers. Also, the "origin" is the scanner itself from what I can gather.